### PR TITLE
fix(boards): #MAG-80 fix duplicate/move to boards without correct rights or in folders

### DIFF
--- a/src/main/java/fr/cgi/magneto/controller/CardController.java
+++ b/src/main/java/fr/cgi/magneto/controller/CardController.java
@@ -30,7 +30,10 @@ import org.entcore.common.http.filter.ResourceFilter;
 import org.entcore.common.http.filter.Trace;
 import org.entcore.common.user.UserUtils;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static fr.cgi.magneto.core.enums.Events.CREATE_MAGNET;

--- a/src/main/java/fr/cgi/magneto/service/BoardService.java
+++ b/src/main/java/fr/cgi/magneto/service/BoardService.java
@@ -52,7 +52,13 @@ public interface BoardService {
      */
     Future<JsonObject> getAllBoards(UserInfos user, Integer page, String searchText, String folderId,
                                     boolean isPublic, boolean isShared, boolean isDeleted, String sortBy);
-
+    /**
+     * Get all boards with publish right
+     *
+     * @param user    {@link UserInfos} User info
+     * @return Future {@link Future <List<Board>} containing list of editable boards
+     */
+    Future<List<Board>> getAllBoardsEditable(UserInfos user);
 
     /**
      * Pre delete boards
@@ -72,4 +78,5 @@ public interface BoardService {
      * @return Future {@link Future <JsonObject>} containing list of deleted boards
      */
     Future<JsonObject> delete(String userId, List<String> boardIds);
+
 }

--- a/src/main/resources/public/ts/directives/card-duplicate-move-lightbox/card-duplicate-move-lightbox.directive.ts
+++ b/src/main/resources/public/ts/directives/card-duplicate-move-lightbox/card-duplicate-move-lightbox.directive.ts
@@ -83,14 +83,7 @@ class Controller implements IViewModel {
      * Get all boards (owner + shared).
      */
     getBoards = async (): Promise<void> => {
-        const params: IBoardsParamsRequest = {
-            isPublic: false,
-            isShared: true,
-            isDeleted: false,
-            sortBy: 'title'
-        };
-
-        boardsService.getAllBoards(params)
+        boardsService.getAllBoardsEditable()
             .then((res: Boards) => {
                 if (res.all && res.all.length > 0) {
                     this.boards.push(...res.all);

--- a/src/main/resources/public/ts/directives/card-move-lightbox/card-move-lightbox.directive.ts
+++ b/src/main/resources/public/ts/directives/card-move-lightbox/card-move-lightbox.directive.ts
@@ -2,7 +2,7 @@ import {idiom as lang, ng, notify, toasts} from "entcore";
 import {IParseService, IScope} from "angular";
 import {RootsConst} from "../../core/constants/roots.const";
 import {boardsService, cardsService} from "../../services";
-import {Board, Boards, Card, CardForm, IBoardsParamsRequest} from "../../models";
+import {Board, Boards, Card, CardForm} from "../../models";
 import {safeApply} from "../../utils/safe-apply.utils";
 import {AxiosError} from "axios";
 import {COMBO_LABELS} from "../../core/enums/comboLabel";
@@ -83,14 +83,7 @@ class Controller implements IViewModel {
      * Get all boards (owner + shared).
      */
     getBoards = async (): Promise<void> => {
-        const params: IBoardsParamsRequest = {
-            isPublic: false,
-            isShared: true,
-            isDeleted: false,
-            sortBy: 'title'
-        };
-
-        boardsService.getAllBoards(params)
+        boardsService.getAllBoardsEditable()
             .then((res: Boards) => {
                 if (res.all && res.all.length > 0) {
                     this.boards.push(...res.all);

--- a/src/main/resources/public/ts/services/boards.service.ts
+++ b/src/main/resources/public/ts/services/boards.service.ts
@@ -5,6 +5,8 @@ import {BoardForm, Boards, IBoardsParamsRequest} from "../models";
 export interface IBoardsService {
     getAllBoards(params: IBoardsParamsRequest): Promise<Boards>;
 
+    getAllBoardsEditable(): Promise<Boards>;
+
     getBoardsByIds(boardIds: Array<string>): Promise<Boards>;
 
     createBoard(params: BoardForm): Promise<AxiosResponse>;
@@ -44,6 +46,11 @@ export const boardsService: IBoardsService = {
 
     getBoardsByIds: async (boardIds: Array<string>): Promise<Boards> => {
         return http.post(`/magneto/boards`, {boardIds: boardIds})
+            .then((res: AxiosResponse) => new Boards(res.data));
+    },
+
+    getAllBoardsEditable: async (): Promise<Boards> => {
+        return http.get(`/magneto/boards/editable`)
             .then((res: AxiosResponse) => new Boards(res.data));
     },
 


### PR DESCRIPTION
## Describe your changes

Created an endpoint to get all boards available for a user (even inside folders). It's a fix for the PR below :
https://github.com/CGI-OPEN-ENT-NG/magneto/pull/35

https://confluence.support-ent.fr/display/RN/Boards

## Checklist tests

Check if we can duplicate and move a card in boards with correct rights or inside folders.

## Issue ticket number and link

https://jira.support-ent.fr/browse/MAG-80
https://jira.support-ent.fr/browse/MAG-98

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [X] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

