### PR TITLE
fix(cards): #MAG-98 fix link icon center and error in cast model

### DIFF
--- a/src/main/java/fr/cgi/magneto/helper/ModelHelper.java
+++ b/src/main/java/fr/cgi/magneto/helper/ModelHelper.java
@@ -17,7 +17,9 @@ public class ModelHelper {
 
     @SuppressWarnings("unchecked")
     public static <T extends Model<T>> List<T> toList(JsonArray results, Class<T> modelClass) {
-        return ((List<JsonObject>) results.getList()).stream()
+        return results.stream()
+                .filter(JsonObject.class::isInstance)
+                .map(JsonObject.class::cast)
                 .map(iModel -> {
                     try {
                         return modelClass.getConstructor(JsonObject.class).newInstance(iModel);

--- a/src/main/resources/public/ts/directives/card-list/card-list-item-preview.html
+++ b/src/main/resources/public/ts/directives/card-list/card-list-item-preview.html
@@ -9,8 +9,8 @@
     <div class="card-list-item-image flex">
         <img ng-if="vm.card.isType(vm.RESOURCE_TYPES.IMAGE)" class="card-list-item-preview-[[vm.card.resourceType]]" ng-src="/workspace/document/[[vm.card.resourceId]]">
         <img ng-if="vm.card.isType(vm.RESOURCE_TYPES.FILE)" class="type-icon" data-ng-src="/magneto/public/img/extension/[[vm.getExtension(vm.card.metadata.filename)]].svg">
-        <a ng-href="[[vm.card.resourceUrl]]" ng-if="vm.card.isType(vm.RESOURCE_TYPES.LINK)" target="_blank">
-            <img class="type-icon" data-ng-src="/magneto/public/img/extension/link.svg">
+        <a ng-href="[[vm.card.resourceUrl]]" class="type-icon" ng-if="vm.card.isType(vm.RESOURCE_TYPES.LINK)" target="_blank">
+            <img data-ng-src="/magneto/public/img/extension/link.svg">
         </a>
         <div ng-if="vm.card.isType(vm.RESOURCE_TYPES.TEXT)" class="card-list-item-preview-[[vm.card.resourceType]]" data-ng-bind-html="vm.getDescriptionHTML(vm.card.description)"></div>
         <audio ng-if="vm.card.isType(vm.RESOURCE_TYPES.AUDIO)" controls preload="none"

--- a/src/test/java/fr/cgi/magneto/helper/IModelHelperTest.java
+++ b/src/test/java/fr/cgi/magneto/helper/IModelHelperTest.java
@@ -1,6 +1,7 @@
 package fr.cgi.magneto.helper;
 
 import fr.cgi.magneto.model.Model;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
@@ -12,6 +13,7 @@ import org.reflections.Reflections;
 
 import java.lang.reflect.Constructor;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -20,22 +22,79 @@ import static org.reflections.scanners.Scanners.SubTypes;
 
 @RunWith(VertxUnitRunner.class)
 public class IModelHelperTest {
+    enum MyEnum {
+        VALUE1,
+        VALUE2,
+        VALUE3
+    }
+
+    static class MyClass {
+        public String id;
+    }
+    static class MyIModel implements Model<MyIModel> {
+        public String id;
+        public boolean isGood;
+        public MyOtherIModel otherIModel;
+        public MyClass myClass;
+        public List<Integer> typeIdList;
+        public List<MyOtherIModel> otherIModelList;
+        public List<MyClass> myClassList;
+        public List<List<JsonObject>> listList;
+        public MyEnum myEnum;
+        public List<MyEnum> myEnumList;
+        public MyEnum nullValue = null;
+
+        @Override
+        public JsonObject toJson() {
+            return null;
+        }
+
+        @Override
+        public MyIModel model(JsonObject model) {
+            return null;
+        }
+    }
+
+    static class MyOtherIModel implements Model<MyOtherIModel> {
+        public String myName;
+
+        public MyOtherIModel() {
+        }
+
+        public MyOtherIModel(JsonObject jsonObject) {
+            this.myName = jsonObject.getString("my_name");
+        }
+
+        @Override
+        public JsonObject toJson() {
+            return null;
+        }
+
+        @Override
+        public MyOtherIModel model(JsonObject model) {
+            return null;
+        }
+    }
+
     private static final Logger log = LoggerFactory.getLogger(IModelHelperTest.class);
 
     @Test
     public void testSubClassIModel(TestContext ctx) {
         Reflections reflections = new Reflections("fr.cgi.magneto");
+        List<Class<?>> ignoredClassList = Arrays.asList(MyIModel.class, MyOtherIModel.class);
 
         Set<Class<?>> subTypes =
                 reflections.get(SubTypes.of(Model.class).asClass());
-        List<Class<?>> invalidModel = subTypes.stream().filter(modelClass -> {
-            Constructor<?> emptyConstructor = Arrays.stream(modelClass.getConstructors())
-                    .filter(constructor -> constructor.getParameterTypes().length == 1
-                            && constructor.getParameterTypes()[0].equals(JsonObject.class))
-                    .findFirst()
-                    .orElse(null);
-            return emptyConstructor == null;
-        }).collect(Collectors.toList());
+        List<Class<?>> invalidModel = subTypes.stream()
+                .filter(modelClass -> !ignoredClassList.contains(modelClass))
+                .filter(modelClass -> {
+                    Constructor<?> emptyConstructor = Arrays.stream(modelClass.getConstructors())
+                            .filter(constructor -> constructor.getParameterTypes().length == 1
+                                    && constructor.getParameterTypes()[0].equals(JsonObject.class))
+                            .findFirst()
+                            .orElse(null);
+                    return emptyConstructor == null;
+                }).collect(Collectors.toList());
 
         invalidModel.forEach(modelClass -> {
             String message = String.format("[Magneto@%s::testSubClassIModel]: The class %s must have public constructor with JsonObject parameter declared",
@@ -44,5 +103,26 @@ public class IModelHelperTest {
         });
 
         ctx.assertTrue(invalidModel.isEmpty(), "One or more IModel don't have public constructor with JsonObject parameter declared. Check log above.");
+    }
+
+    @Test
+    public void testLinkedMap(TestContext ctx) {
+        LinkedHashMap<Object, Object> linkedHashMap = new LinkedHashMap<>();
+        LinkedHashMap<Object, Object> linkedHashMap2 = new LinkedHashMap<>();
+        LinkedHashMap<Object, Object> linkedHashMap3 = new LinkedHashMap<>();
+        LinkedHashMap<Object, Object> linkedHashMap4 = new LinkedHashMap<>();
+        linkedHashMap.put("my_name", "name1");
+        linkedHashMap2.put("my_name", "name2");
+        //Is instance is not a MyOtherIModel, so it will not be added to the list
+        linkedHashMap3.put("my_name", new MyClass());
+        linkedHashMap4.put(3, "name3");
+
+        List<MyOtherIModel> list = ModelHelper.toList(new JsonArray(Arrays.asList(linkedHashMap, linkedHashMap2, linkedHashMap3,
+                linkedHashMap4)), MyOtherIModel.class);
+
+        ctx.assertEquals(list.size(), 3);
+        ctx.assertEquals(list.get(0).myName, "name1");
+        ctx.assertEquals(list.get(1).myName, "name2");
+        ctx.assertEquals(list.get(2).myName, null);
     }
 }


### PR DESCRIPTION
## Describe your changes

When you create a JsonObject from a list containing LinkerHashMap, and you retrieve this list (JsonArray#getList) you cannot cast this list into a list of JsonObject. If we stream directly (JsonArray#stream) on the JsonArray, the LinkerHashMap elements of the stream are directly converted into JsonObject.

Link icon is not centered in cards.

## Checklist tests

Check if link cards are correctly centered
Check if we can create a JsonObject from a list containing LinkerHashMap

## Issue ticket number and link

https://github.com/CGI-OPEN-ENT-NG/magneto/issues/42
https://jira.support-ent.fr/browse/MAG-98

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [X] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

